### PR TITLE
Add zeek/zeek-version.h include

### DIFF
--- a/src/bsap.h
+++ b/src/bsap.h
@@ -3,6 +3,12 @@
 #ifndef ANALYZER_PROTOCOL_BSAP_H
 #define ANALYZER_PROTOCOL_BSAP_H
 
+#if __has_include(<zeek/zeek-version.h>)
+#include <zeek/zeek-version.h>
+#else
+#include <zeek/zeek-config.h>
+#endif
+
 #include "events.bif.h"
 #if ZEEK_VERSION_NUMBER >= 40100
 #include <zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h>


### PR DESCRIPTION
Due to zeek/zeek#2806 with the latest master version this requires an explicit `zeek/zeek-version.h` include. That include is good practice anyway.

Reference zeek/zeek#2847.

Originally suggested by @awelzel in cisagov/icsnpp-bacnet#19.