### PR TITLE
Align comment style with zeek comment style so docs generation works

### DIFF
--- a/scripts/icsnpp/bsap/main.zeek
+++ b/scripts/icsnpp/bsap/main.zeek
@@ -27,15 +27,15 @@ export {
     #############################  BSAP_IP_Header -> bsap_ip_header.log  ###########################
     ###############################################################################################
     type BSAP_IP_Header: record {
-        ts              : time      &log;                   ## Timestamp for when the event happened.
-        uid             : string    &log;                   ## Unique ID for the connection.
-        id              : conn_id   &log;                   ## The connection's 4-tuple of endpoint addresses/ports.
-        is_orig         : bool      &log;                   ## the message came from the originator/client or the responder/server
-        source_h        : addr      &log;                   ## Source IP Address
-        source_p        : port      &log;                   ## Source Port
-        destination_h   : addr      &log;                   ## Destination IP Address
-        destination_p   : port      &log;                   ## Destination Port
-        num_msg         : count     &log;                   ## Number of function calls in message packet
+        ts              : time      &log;                   ##< Timestamp for when the event happened.
+        uid             : string    &log;                   ##< Unique ID for the connection.
+        id              : conn_id   &log;                   ##< The connection's 4-tuple of endpoint addresses/ports.
+        is_orig         : bool      &log;                   ##< the message came from the originator/client or the responder/server
+        source_h        : addr      &log;                   ##< Source IP Address
+        source_p        : port      &log;                   ##< Source Port
+        destination_h   : addr      &log;                   ##< Destination IP Address
+        destination_p   : port      &log;                   ##< Destination Port
+        num_msg         : count     &log;                   ##< Number of function calls in message packet
         type_name       : string    &log;
         # ## TODO: Add other fields here that you'd like to log.
     };
@@ -46,15 +46,15 @@ export {
     ################################  BSAP_IP_RDB -> bsap_ip_rdb.log  ################################
     ###############################################################################################
     type BSAP_IP_RDB: record {
-        ts              : time              &log;        ## Timestamp for when the event happened.
-        uid             : string            &log;        ## Unique ID for the connection.
-        id              : conn_id           &log;        ## The connection's 4-tuple of endpoint addresses/ports.
-        is_orig         : bool              &log;        ## the message came from the originator/client or the responder/server
-        source_h        : addr              &log;        ## Source IP Address
-        source_p        : port              &log;        ## Source Port
-        destination_h   : addr              &log;        ## Destination IP Address
-        destination_p   : port              &log;        ## Destination Port
-        header_size     : count             &log;        ## The connection's 4-tuple of endpoint addresses/ports.
+        ts              : time              &log;        ##< Timestamp for when the event happened.
+        uid             : string            &log;        ##< Unique ID for the connection.
+        id              : conn_id           &log;        ##< The connection's 4-tuple of endpoint addresses/ports.
+        is_orig         : bool              &log;        ##< the message came from the originator/client or the responder/server
+        source_h        : addr              &log;        ##< Source IP Address
+        source_p        : port              &log;        ##< Source Port
+        destination_h   : addr              &log;        ##< Destination IP Address
+        destination_p   : port              &log;        ##< Destination Port
+        header_size     : count             &log;        ##< The connection's 4-tuple of endpoint addresses/ports.
         mes_seq         : count             &log;
         res_seq         : count             &log;
         data_len        : count             &log;
@@ -74,14 +74,14 @@ export {
     ############################  BSAP_IP_UNKNOWN -> bsap_ip_unknown.log  ##########################
     ###############################################################################################
     type BSAP_IP_UNKNOWN: record {
-        ts              : time      &log;                   ## Timestamp for when the event happened.
-        uid             : string    &log;                   ## Unique ID for the connection.
-        id              : conn_id   &log;                   ## The connection's 4-tuple of endpoint addresses/ports.
-        is_orig         : bool      &log;                   ## the message came from the originator/client or the responder/server
-        source_h        : addr      &log;                   ## Source IP Address
-        source_p        : port      &log;                   ## Source Port
-        destination_h   : addr      &log;                   ## Destination IP Address
-        destination_p   : port      &log;                   ## Destination Port
+        ts              : time      &log;                   ##< Timestamp for when the event happened.
+        uid             : string    &log;                   ##< Unique ID for the connection.
+        id              : conn_id   &log;                   ##< The connection's 4-tuple of endpoint addresses/ports.
+        is_orig         : bool      &log;                   ##< the message came from the originator/client or the responder/server
+        source_h        : addr      &log;                   ##< Source IP Address
+        source_p        : port      &log;                   ##< Source Port
+        destination_h   : addr      &log;                   ##< Destination IP Address
+        destination_p   : port      &log;                   ##< Destination Port
         data            : string    &log;
         # ## TODO: Add other fields here that you'd like to log.
     };
@@ -93,14 +93,14 @@ export {
     ###############################################################################################
 
     type BSAP_SERIAL_HEADER: record {
-        ts              : time      &log;                   ## Timestamp for when the event happened.
-        uid             : string    &log;                   ## Unique ID for the connection.
-        id              : conn_id   &log;                   ## The connection's 4-tuple of endpoint addresses/ports.
-        is_orig         : bool      &log;                   ## the message came from the originator/client or the responder/server
-        source_h        : addr      &log;                   ## Source IP Address
-        source_p        : port      &log;                   ## Source Port
-        destination_h   : addr      &log;                   ## Destination IP Address
-        destination_p   : port      &log;                   ## Destination Port
+        ts              : time      &log;                   ##< Timestamp for when the event happened.
+        uid             : string    &log;                   ##< Unique ID for the connection.
+        id              : conn_id   &log;                   ##< The connection's 4-tuple of endpoint addresses/ports.
+        is_orig         : bool      &log;                   ##< the message came from the originator/client or the responder/server
+        source_h        : addr      &log;                   ##< Source IP Address
+        source_p        : port      &log;                   ##< Source Port
+        destination_h   : addr      &log;                   ##< Destination IP Address
+        destination_p   : port      &log;                   ##< Destination Port
         ser             : count     &log;
         dadd            : count     &log;
         sadd            : count     &log;
@@ -120,14 +120,14 @@ export {
     ###############################################################################################
 
     type BSAP_SERIAL_RDB: record {
-        ts              : time              &log;                   ## Timestamp for when the event happened.
-        uid             : string            &log;                   ## Unique ID for the connection.
-        id              : conn_id           &log;                   ## The connection's 4-tuple of endpoint addresses/ports.
-        is_orig         : bool              &log;                   ## the message came from the originator/client or the responder/server
-        source_h        : addr              &log;                   ## Source IP Address
-        source_p        : port              &log;                   ## Source Port
-        destination_h   : addr              &log;                   ## Destination IP Address
-        destination_p   : port              &log;                   ## Destination Port
+        ts              : time              &log;                   ##< Timestamp for when the event happened.
+        uid             : string            &log;                   ##< Unique ID for the connection.
+        id              : conn_id           &log;                   ##< The connection's 4-tuple of endpoint addresses/ports.
+        is_orig         : bool              &log;                   ##< the message came from the originator/client or the responder/server
+        source_h        : addr              &log;                   ##< Source IP Address
+        source_p        : port              &log;                   ##< Source Port
+        destination_h   : addr              &log;                   ##< Destination IP Address
+        destination_p   : port              &log;                   ##< Destination Port
         func_code       : string            &log;
         variable_count  : count             &log;
         variables       : vector of string  &log &optional;
@@ -142,14 +142,14 @@ export {
     ###############################################################################################
 
     type BSAP_SERIAL_RDB_EXT: record {
-        ts              : time      &log;                   ## Timestamp for when the event happened.
-        uid             : string    &log;                   ## Unique ID for the connection.
-        id              : conn_id   &log;                   ## The connection's 4-tuple of endpoint addresses/ports.
-        is_orig         : bool      &log;                   ## the message came from the originator/client or the responder/server
-        source_h        : addr      &log;                   ## Source IP Address
-        source_p        : port      &log;                   ## Source Port
-        destination_h   : addr      &log;                   ## Destination IP Address
-        destination_p   : port      &log;                   ## Destination Port
+        ts              : time      &log;                   ##< Timestamp for when the event happened.
+        uid             : string    &log;                   ##< Unique ID for the connection.
+        id              : conn_id   &log;                   ##< The connection's 4-tuple of endpoint addresses/ports.
+        is_orig         : bool      &log;                   ##< the message came from the originator/client or the responder/server
+        source_h        : addr      &log;                   ##< Source IP Address
+        source_p        : port      &log;                   ##< Source Port
+        destination_h   : addr      &log;                   ##< Destination IP Address
+        destination_p   : port      &log;                   ##< Destination Port
         dfun            : string    &log;
         seq             : count     &log;
         sfun            : string    &log;
@@ -166,14 +166,14 @@ export {
     ###############################################################################################
 
     type BSAP_SERIAL_UNKNOWN: record {
-        ts              : time      &log;                   ## Timestamp for when the event happened.
-        uid             : string    &log;                   ## Unique ID for the connection.
-        id              : conn_id   &log;                   ## The connection's 4-tuple of endpoint addresses/ports.
-        is_orig         : bool      &log;                   ## the message came from the originator/client or the responder/server
-        source_h        : addr      &log;                   ## Source IP Address
-        source_p        : port      &log;                   ## Source Port
-        destination_h   : addr      &log;                   ## Destination IP Address
-        destination_p   : port      &log;                   ## Destination Port
+        ts              : time      &log;                   ##< Timestamp for when the event happened.
+        uid             : string    &log;                   ##< Unique ID for the connection.
+        id              : conn_id   &log;                   ##< The connection's 4-tuple of endpoint addresses/ports.
+        is_orig         : bool      &log;                   ##< the message came from the originator/client or the responder/server
+        source_h        : addr      &log;                   ##< Source IP Address
+        source_p        : port      &log;                   ##< Source Port
+        destination_h   : addr      &log;                   ##< Destination IP Address
+        destination_p   : port      &log;                   ##< Destination Port
         data            : string    &log;
         # ## TODO: Add other fields here that you'd like to log.
     };


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

When you do single line comments in Zeek, zeekygen expects ##< to signal where they apply, so changed single hashes to those.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Fixes automated documentation and schema generation.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
